### PR TITLE
Light Code Review

### DIFF
--- a/INCON/INC_undercover/Scripts/civChaosHandler.sqf
+++ b/INCON/INC_undercover/Scripts/civChaosHandler.sqf
@@ -18,10 +18,16 @@ if (missionNamespace getVariable ["civiliansTargeted",false]) exitWith {};
 		missionNameSpace setVariable ["civiliansTargeted", true, true];
 		//Enemies target civs
 		{
-			if (((side _x) == Civilian) && !(_x getVariable ["isUndercover", false])) then {
+			if (((side _x) == Civilian) && {!(_x getVariable ["isUndercover", false])}) then {
 				if (_percentageTarget > (random 100)) then {
+					private _prevGroup = group _x;
+
 					[_x] joinSilent grpNull;
 					[_x] joinSilent (group rebelCommander);
+
+					if ((count _units group _prevGroup) == 0) then {
+						deleteGroup _prevGroup; // clean up empty groups
+					};
 				};
 			};
 		} foreach allunits;
@@ -33,30 +39,37 @@ if (missionNamespace getVariable ["civiliansTargeted",false]) exitWith {};
 	//Armed civs will rebel
 	if (_rebelChance > (random 100)) then {
 		{
-			if ((side _x) == Civilian) then {
-				if !(_x getVariable ["isUndercover", false]) then {
-					if !(_x getVariable ["civIsUnarmed", false]) then {
-						if (_percentageRebel > (random 100)) then {
-							[_x] joinSilent grpNull;
-							[_x] joinSilent (group rebelCommander);
-							if (_x getVariable ["civRifle",false]) exitWith {
-								removeAllWeapons _x;
-								_x addMagazine "30Rnd_762x39_Mag_Tracer_F";
-								_x addWeapon "arifle_AKM_F";
-								_x addMagazine "30Rnd_762x39_Mag_Tracer_F";
-								_x addMagazine "30Rnd_762x39_Mag_Tracer_F";
-								_x setUnitAbility (0.7 + (random 0.25));
-							};
-							removeAllWeapons _x;
-							_x addMagazine "16Rnd_9x21_Mag";
-							_x addWeapon "hgun_Rook40_F";
-							_x addMagazine "16Rnd_9x21_Mag";
-							_x addMagazine "16Rnd_9x21_Mag";
-							_x addMagazine "16Rnd_9x21_Mag";
-							_x setUnitAbility (0.7 + (random 0.25));
-						};
-					};
+			if (
+				((side _x) == Civilian) &&
+				{!(_x getVariable ["isUndercover", false])} &&
+				{!(_x getVariable ["civIsUnarmed", false])} &&
+				{_percentageRebel > (random 100)}
+			) then {
+				private _prevGroup = group _x;
+
+				[_x] joinSilent grpNull;
+				[_x] joinSilent (group rebelCommander);
+
+				if ((count units group _prevGroup) == 0) then {
+					deleteGroup _prevGroup;
 				};
+
+				if (_x getVariable ["civRifle",false]) exitWith {
+					removeAllWeapons _x;
+					_x addMagazine "30Rnd_762x39_Mag_Tracer_F";
+					_x addWeapon "arifle_AKM_F";
+					_x addMagazine "30Rnd_762x39_Mag_Tracer_F";
+					_x addMagazine "30Rnd_762x39_Mag_Tracer_F";
+					_x setUnitAbility (0.7 + (random 0.25));
+				};
+
+				removeAllWeapons _x;
+				_x addMagazine "16Rnd_9x21_Mag";
+				_x addWeapon "hgun_Rook40_F";
+				_x addMagazine "16Rnd_9x21_Mag";
+				_x addMagazine "16Rnd_9x21_Mag";
+				_x addMagazine "16Rnd_9x21_Mag";
+				_x setUnitAbility (0.7 + (random 0.25));
 			};
 		} foreach allunits;
 	};

--- a/INCON/INC_undercover/func/fn_countAlerted.sqf
+++ b/INCON/INC_undercover/func/fn_countAlerted.sqf
@@ -8,7 +8,7 @@ Returns number of units with beef against the target unit.
 
 */
 
-private ["_alertedUnits","_getHideFromUnit"];
+private ["_alertedUnits","_GroupsKnowAboutUnit","_getHideFromUnit"];
 
 params [["_side",sideEmpty],["_detectedUnit",player],["_distSqr",1400]];
 
@@ -18,7 +18,7 @@ _alertedUnits = [];
 
 _GroupsKnowAboutUnit = allGroups select {
 
-    (side _x isEqualTo _side) && {((leader _x getHideFrom _detectedUnit) distanceSqr _detectedUnit < _distSqr) && (alive leader _x) && (!captive leader _x)}
+    (side _x isEqualTo _side) && {((leader _x getHideFrom _detectedUnit) distanceSqr _detectedUnit < _distSqr) && {alive leader _x} && {!captive leader _x}}
 
 };
 

--- a/INCON/INC_undercover/func/fn_getFactionGear.sqf
+++ b/INCON/INC_undercover/func/fn_getFactionGear.sqf
@@ -4,6 +4,7 @@ Author: Spyderblack723
 
 */
 
+private ["_unit","_linkedItems"];
 
 params ["_gearType","_factions"];
 

--- a/INCON/INC_undercover/func/fn_recruitAttempt.sqf
+++ b/INCON/INC_undercover/func/fn_recruitAttempt.sqf
@@ -10,7 +10,7 @@ _INC_undercoverSide = toUpper (str (side _undercoverUnit));
 _percentage = ((([ALIVE_civilianHostility, _INC_undercoverSide] call ALIVE_fnc_hashGet) / 2)+ 20);
 
 if (_percentage > 30) then {
-    if ((_percentage > (random 100)) && (_undercoverUnit getVariable ["isUndercover", false])) then {
+    if ((_percentage > (random 100)) && {_undercoverUnit getVariable ["isUndercover", false]}) then {
 
         if (_undercoverGroup < (5 + (ceil random 5))) then {
 
@@ -33,7 +33,7 @@ if (_percentage > 30) then {
 
 } else {
 
-    if ((_percentage > (random 100)) && (_undercoverUnit getVariable ["isUndercover", false]) && !(_undercoverUnit getVariable ["INC_undercoverCompromised", false])) then {
+    if ((_percentage > (random 100)) && {_undercoverUnit getVariable ["isUndercover", false]} && {!(_undercoverUnit getVariable ["INC_undercoverCompromised", false])}) then {
 
         if (_undercoverGroup < (2 + (random 5))) then {
 

--- a/INCON/INC_undercover/func/fn_recruitSuccess.sqf
+++ b/INCON/INC_undercover/func/fn_recruitSuccess.sqf
@@ -82,7 +82,7 @@ _recruitedCiv setUnitAbility _skill;
 
 			_weaponType = currentWeapon _unit;
 
-			if ((_weaponType == "") || (_weaponType == "Throw")) exitWith {
+			if ((_weaponType == "") || {_weaponType == "Throw"}) exitWith {
 				private _civComment = selectRandom ["I'm unarmed, let's find a weapon.","I need to find a weapon.","I've got no weapon."];
 				[[_unit, _civComment] remoteExec ["globalChat",0]];
 			};

--- a/INCON/INC_undercover/func/fn_runAway.sqf
+++ b/INCON/INC_undercover/func/fn_runAway.sqf
@@ -1,3 +1,7 @@
 params [["_unit",objNull]];
 
-_unit doMove [((getPosASL _unit select 0) + (5 + (random 3) - (random 16))),((getPosASL _unit select 1) + (5 + (random 3))),(getPosASL _unit select 2)];
+_unit doMove [
+	(getPosASL _unit select 0) + (5 + (random 3) - (random 16)),
+	(getPosASL _unit select 1) + (5 + (random 3)),
+	getPosASL _unit select 2
+];

--- a/INCON/INC_undercover/func/fn_simpleArmedTracker.sqf
+++ b/INCON/INC_undercover/func/fn_simpleArmedTracker.sqf
@@ -24,7 +24,7 @@ _safeUniforms append (["uniforms",_safeFactionUniforms] call INCON_fnc_getFactio
 
 	params ["_civ","_safeUniforms","_safeVests"];
 
-	if ((_civ getVariable ["INC_civArmedLoopRunning",false]) || (isDedicated) || (_civ == player)) exitWith {};
+	if ((_civ getVariable ["INC_civArmedLoopRunning",false]) || {isDedicated} || {_civ == player}) exitWith {};
 
 	_civ setVariable ["INC_civArmedLoopRunning", true, true]; // Stops the script running twice on the same unit
 
@@ -36,14 +36,14 @@ _safeUniforms append (["uniforms",_safeFactionUniforms] call INCON_fnc_getFactio
 
 		waitUntil {
 			sleep 5;
-			(!(uniform _civ in _safeUniforms) || !(vest _civ in _safeVests) || !((currentWeapon _civ == "") || (currentWeapon _civ == "Throw")) || (hmd _civ != "")); //Fires if unit gets out weapon or wears suspicious uniform.
+			(!(uniform _civ in _safeUniforms) || {!(vest _civ in _safeVests)} || {!((currentWeapon _civ == "") || {currentWeapon _civ == "Throw"})} || {hmd _civ != ""}); //Fires if unit gets out weapon or wears suspicious uniform.
 		};
 
 		[_civ, false] remoteExec ["setCaptive", _civ];
 
 		waitUntil {
 			sleep 5;
-			!(!(uniform _civ in _safeUniforms) || !(vest _civ in _safeVests) || !((currentWeapon _civ == "") || (currentWeapon _civ == "Throw")) || (hmd _civ != "")); //Fires if unit gets out weapon or wears suspicious uniform.
+			!(!(uniform _civ in _safeUniforms) || {!(vest _civ in _safeVests)} || {!((currentWeapon _civ == "") || {currentWeapon _civ == "Throw"})} || {hmd _civ != ""}); //Fires if unit gets out weapon or wears suspicious uniform.
 		};
 
 		[_civ, true] remoteExec ["setCaptive", _civ];

--- a/INCON/INC_undercover/func/fn_spawnRebelCommander.sqf
+++ b/INCON/INC_undercover/func/fn_spawnRebelCommander.sqf
@@ -5,7 +5,7 @@ if (missionNamespace getVariable ["INC_rebelCommanderSpawned",false]) exitWith {
 
 if (isNil "rebelCommander") then {
 
-	_rebelGroup = [[40,40,10], _side, 1] call BIS_fnc_spawnGroup;
+	private _rebelGroup = [[40,40,10], _side, 1] call BIS_fnc_spawnGroup;
 	rebelCommander = leader _rebelGroup;
 	rebelCommander setRank "COLONEL";
 	rebelCommander disableAI "ALL";
@@ -17,5 +17,6 @@ if (isNil "rebelCommander") then {
 	rebelCommander hideObject true;
 	rebelCommander setUnitAbility 1;
 	INC_rebelCommanderSpawned = true;
-	publicVariable "INC_rebelCommanderSpawned"; 
+	publicVariable "INC_rebelCommanderSpawned";
+
 };

--- a/INCON/INC_undercover/func/fn_undercoverArmedTracker.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverArmedTracker.sqf
@@ -41,7 +41,7 @@ _underCoverUnit setVariable ["INC_armedLoopRunning", true, true]; // Stops the s
 
 		waitUntil {
 			sleep 3;
-			(!(uniform _underCoverUnit in _safeUniforms) || !((vest _underCoverUnit in _safeVests) || (vest _underCoverUnit == "")) || !((currentWeapon _underCoverUnit == "") || (currentWeapon _underCoverUnit == "Throw")) || (hmd _underCoverUnit != "")); //Fires if unit gets out weapon or wears suspicious uniform.
+			(!(uniform _underCoverUnit in _safeUniforms) || {!((vest _underCoverUnit in _safeVests) || {vest _underCoverUnit == ""})} || {!((currentWeapon _underCoverUnit == "") || {currentWeapon _underCoverUnit == "Throw"})} || {hmd _underCoverUnit != ""}); //Fires if unit gets out weapon or wears suspicious uniform.
 		};
 
 		_underCoverUnit setVariable ["INC_armed", true, true]; // Sets variable "INC_armed" as true.
@@ -50,10 +50,10 @@ _underCoverUnit setVariable ["INC_armedLoopRunning", true, true]; // Stops the s
 
 		waitUntil {
 			sleep 3;
-			!(!(uniform _underCoverUnit in _safeUniforms) || !((vest _underCoverUnit in _safeVests) || (vest _underCoverUnit == "")) || !((currentWeapon _underCoverUnit == "") || (currentWeapon _underCoverUnit == "Throw")) || (hmd _underCoverUnit != "")); //Fires if unit gets out weapon or wears suspicious uniform.
+			!(!(uniform _underCoverUnit in _safeUniforms) || {!((vest _underCoverUnit in _safeVests) || {vest _underCoverUnit == ""})} || {!((currentWeapon _underCoverUnit == "") || {currentWeapon _underCoverUnit == "Throw"})} || {hmd _underCoverUnit != ""}); //Fires if unit gets out weapon or wears suspicious uniform.
 		};
 
-		(!(_undercoverUnit getVariable ["isUndercover",false]) || !(alive _undercoverUnit))
+		(!(_undercoverUnit getVariable ["isUndercover",false]) || {!(alive _undercoverUnit)})
 
 	};
 

--- a/INCON/INC_undercover/func/fn_undercoverCompromised.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverCompromised.sqf
@@ -60,9 +60,9 @@ if (_underCoverUnit getVariable ["INC_compromisedLoopRunning",false]) exitWith {
 			sleep 11;
 			(
 				!(_underCoverUnit getVariable ["INC_AnyKnowsSO",false]) &&
-				!(_underCoverUnit getVariable ["INC_armed",false]) &&
-				!(_underCoverUnit getVariable ["INC_trespassing",false]) &&
-				(1.8 > (_regEnySide knowsAbout _underCoverUnit))
+				{!(_underCoverUnit getVariable ["INC_armed",false])} &&
+				{!(_underCoverUnit getVariable ["INC_trespassing",false])} &&
+				{(1.8 > (_regEnySide knowsAbout _underCoverUnit))}
 			);
 		};
 
@@ -79,8 +79,8 @@ if (_underCoverUnit getVariable ["INC_compromisedLoopRunning",false]) exitWith {
 			sleep 3;
 			(
 				!(_underCoverUnit getVariable ["INC_AnyKnowsSO",false]) &&
-				!(_underCoverUnit getVariable ["INC_armed",false]) &&
-				!(_underCoverUnit getVariable ["INC_trespassing",false])
+				{!(_underCoverUnit getVariable ["INC_armed",false])} &&
+				{!(_underCoverUnit getVariable ["INC_trespassing",false])}
 			);
 		};
 

--- a/INCON/INC_undercover/func/fn_undercoverCooldown.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverCooldown.sqf
@@ -59,7 +59,7 @@ _underCoverUnit setVariable ["INC_cooldown", true, true];
 
 
 	//SetsCaptive back to true if nobody has seen him, unless he is already compromised
-	if !((_asymKnowsAboutUnit) || (_regKnowsAboutUnit)) exitWith {
+	if !((_asymKnowsAboutUnit) || {_regKnowsAboutUnit}) exitWith {
 
 		if !(_underCoverUnit getVariable ["INC_undercoverCompromised",false]) then {
 			[_underCoverUnit, true] remoteExec ["setCaptive", _underCoverUnit];
@@ -69,11 +69,11 @@ _underCoverUnit setVariable ["INC_cooldown", true, true];
 	};
 
 	//If both _regEnySide and _asymEnySide know about the unit, wait until neither does.
-	if ((_asymKnowsAboutUnit) && (_regKnowsAboutUnit)) exitWith {
+	if ((_asymKnowsAboutUnit) && {_regKnowsAboutUnit}) exitWith {
 
 		waitUntil {
 			sleep 2;
-			(!(_underCoverUnit getVariable ["INC_AnyKnowsSO",false]) && !(_underCoverUnit getVariable ["INC_armed",false]) && !(_underCoverUnit getVariable ["INC_trespassing",false]))
+			(!(_underCoverUnit getVariable ["INC_AnyKnowsSO",false]) && {!(_underCoverUnit getVariable ["INC_armed",false])} && {!(_underCoverUnit getVariable ["INC_trespassing",false])})
 		};
 
 		if !(_underCoverUnit getVariable ["INC_undercoverCompromised",false]) then {
@@ -89,7 +89,7 @@ _underCoverUnit setVariable ["INC_cooldown", true, true];
 
 		waitUntil {
 			sleep 10;
-			(!(_underCoverUnit getVariable ["INC_AsymKnowsSO",false]) && !(_underCoverUnit getVariable ["INC_armed",false]) && !(_underCoverUnit getVariable ["INC_trespassing",false]))
+			(!(_underCoverUnit getVariable ["INC_AsymKnowsSO",false]) && {!(_underCoverUnit getVariable ["INC_armed",false])} && {!(_underCoverUnit getVariable ["INC_trespassing",false])})
 		};
 
 	//Otherwise, only _regEnySide knows about the unit so wait until they no longer do.
@@ -97,7 +97,7 @@ _underCoverUnit setVariable ["INC_cooldown", true, true];
 
 		waitUntil {
 			sleep 10;
-			(!(_underCoverUnit getVariable ["INC_RegKnowsSO",false]) && !(_underCoverUnit getVariable ["INC_armed",false]) && !(_underCoverUnit getVariable ["INC_trespassing",false]))
+			(!(_underCoverUnit getVariable ["INC_RegKnowsSO",false]) && {!(_underCoverUnit getVariable ["INC_armed",false])} && {!(_underCoverUnit getVariable ["INC_trespassing",false])})
 		};
 
 		//Percentage chance that unit will become compromised anyway

--- a/INCON/INC_undercover/func/fn_undercoverDetect.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverDetect.sqf
@@ -19,13 +19,13 @@ if (_underCoverUnit getVariable ["undercoverDetectionRunning",false]) exitWith {
 
 		sleep 5;
 
-		_alertedRegKnows = ([_underCoverUnit, _regEnySide] call INCON_fnc_undercoverGetAlerted);
+		private _alertedRegKnows = ([_underCoverUnit, _regEnySide] call INCON_fnc_undercoverGetAlerted);
 
-		_alertedAsymKnows = ([_underCoverUnit, _asymEnySide] call INCON_fnc_undercoverGetAlerted);
+		private _alertedAsymKnows = ([_underCoverUnit, _asymEnySide] call INCON_fnc_undercoverGetAlerted);
 
-		_anyAlerted = false;
+		private _anyAlerted = false;
 
-		if (_alertedRegKnows || _alertedAsymKnows) then {_anyAlerted = true};
+		if (_alertedRegKnows || {_alertedAsymKnows}) then {_anyAlerted = true};
 
 		//Publicise variables on undercover unit for undercover handler, killed handler & cooldown.
 		_underCoverUnit setVariable ["INC_RegKnowsSO", _alertedRegKnows, true];

--- a/INCON/INC_undercover/func/fn_undercoverFiredEH.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverFiredEH.sqf
@@ -31,7 +31,7 @@ _underCoverUnit addEventHandler["Fired", {
 			_asymAlerted = [INC_ucr_firedEhAsym,_underCoverUnit,50] call INCON_fnc_countAlerted;
 
 			//Once people know where he is, who he is, and that he has fired a weapon, make him compromised
-			if ((_regAlerted != 0) || (_asymAlerted != 0)) exitWith {
+			if ((_regAlerted != 0) || {_asymAlerted != 0}) exitWith {
 
 				[_underCoverUnit] call INCON_fnc_undercoverCompromised;
 			};

--- a/INCON/INC_undercover/func/fn_undercoverGetAlerted.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverGetAlerted.sqf
@@ -9,17 +9,10 @@ params [["_unit",player],["_detectingSide",sideEmpty]];
 if (_detectingSide isEqualTo sideEmpty) exitWith {false};
 
 _alertedGroups = allGroups select {
-	if (side _x isEqualTo _detectingSide) then {
-		if (alive leader _x) then {
-			if ((leader _x targetKnowledge _unit) select 0) then {
-				if (!captive leader _x) then {
-					true
-				};
-			};
-		};
-	};
+	(side _x isEqualTo _detectingSide) &&
+	{alive leader _x} &&
+	{(leader _x targetKnowledge _unit) select 0} &&
+	{!captive leader _x}
 };
 
-if ((count _alertedGroups) != 0) exitWith {true};
-
-false
+if ((count _alertedGroups) == 0) then {false} else {true}

--- a/INCON/INC_undercover/func/fn_undercoverKilledHandler.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverKilledHandler.sqf
@@ -19,9 +19,7 @@ Barbaric (bool) - if true, the unit's side will potentially lash out against civ
 
 params [["_unit",objNull],["_barbaric",false],["_undercoverUnitSide",west]];
 
-if ((_unit getVariable ["INC_undercoverSide",sideEmpty]) isEqualTo _undercoverUnitSide) exitWith {};
-
-if (isNil "ALIVE_fnc_hashGet") exitWith {};
+if ((_unit getVariable ["INC_undercoverSide",sideEmpty]) isEqualTo _undercoverUnitSide || {isNil "ALIVE_fnc_hashGet"}) exitWith {};
 
 _unit setVariable ["INC_undercoverSide",_undercoverUnitSide,true];
 
@@ -112,9 +110,9 @@ if (_barbaric) then {
 
 					if (40 > (random 100)) then {
 
-						_oldHostility = [ALIVE_civilianHostility, _INC_undercoverSide] call ALIVE_fnc_hashGet;
+						private _oldHostility = [ALIVE_civilianHostility, _INC_undercoverSide] call ALIVE_fnc_hashGet;
 
-						_newHostility = _oldHostility + (random 10);
+						private _newHostility = _oldHostility + (random 10);
 
 						[ALIVE_civilianHostility, _INC_undercoverSide,_newHostility] call ALIVE_fnc_hashSet;
 
@@ -133,13 +131,10 @@ if (_barbaric) then {
 
 				private _nearbyUndercoverUnits = ((_unit nearEntities ["Man", 700]) select {
 
-					if (_x getVariable ["isSneaky",false]) then {
-
-						if ((_side knowsAbout _x) > 3.5) then {
+					if (_x getVariable ["isSneaky",false] && {(_side knowsAbout _x) > 3.5}) then {
 
 							true;
 
-						}
 					}
 				});
 
@@ -154,12 +149,13 @@ if (_barbaric) then {
 				};
 
 				//If there is no known suspect and the killer was an undercover unit, then there's a 10% chance they will lash out against civilians
-				if ((33 > (random 100)) && (_killer getVariable ["isSneaky",false])) then {
+				if ((33 > (random 100)) && {_killer getVariable ["isSneaky",false]}) then {
 
 					//makes this side consider civilians a threat if they start to die and know about the underCoverUnit, also make civilians hostile to this side
 					[[80,20], "INCON\INC_undercover\Scripts\civChaosHandler.sqf"] remoteExec ["execVM",2];
 
-					[ALIVE_civilianHostility,toUpper (str _side),-100] call ALIVE_fnc_hashSet;
+					private _sideText = [[_side] call ALIVE_fnc_sideObjectToNumber] call ALIVE_fnc_sideNumberToText;
+					[ALIVE_civilianHostility, _sideText,-100] call ALIVE_fnc_hashSet;
 				};
 
 			};

--- a/INCON/INC_undercover/func/fn_undercoverTrespassHandler.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverTrespassHandler.sqf
@@ -43,8 +43,8 @@ _undercoverUnit setVariable ["INC_trespassType2",false,true];
 		waitUntil {
 			sleep 2;
 			(
-				(_undercoverUnit getVariable ["INC_trespassType1",false])
-				|| (_undercoverUnit getVariable ["INC_trespassType2",false])
+				(_undercoverUnit getVariable ["INC_trespassType1",false]) ||
+				{_undercoverUnit getVariable ["INC_trespassType2",false]}
 			); //Fires if any of the trespassing types are met.
 		};
 
@@ -53,14 +53,14 @@ _undercoverUnit setVariable ["INC_trespassType2",false,true];
 		waitUntil {
 			sleep 2;
 			!(
-				(_undercoverUnit getVariable ["INC_trespassType1",false])
-				|| (_undercoverUnit getVariable ["INC_trespassType2",false])
+				(_undercoverUnit getVariable ["INC_trespassType1",false]) ||
+				{_undercoverUnit getVariable ["INC_trespassType2",false]}
 			); //Fires if all of the trespassing types are inactive.
 		};
 
 		_undercoverUnit setVariable ["INC_trespassing", false, true]; //Publicises trespassing variable on unit to false.
 
-		(!(_undercoverUnit getVariable ["isUndercover",false]) || !(alive _undercoverUnit))
+		(!(_undercoverUnit getVariable ["isUndercover",false]) || {!(alive _undercoverUnit)})
 	};
 };
 

--- a/INCON/INC_undercover/func/fn_undercoverTrespassMarkerLoop.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverTrespassMarkerLoop.sqf
@@ -1,6 +1,6 @@
 params [["_undercoverUnit",objNull],["_trespassMarkers",[]]];
 
-if ((!local _undercoverUnit) || (_undercoverUnit getVariable ["INC_trespassMarkerLoopRunning",false])) exitWith {};
+if ((!local _undercoverUnit) || {_undercoverUnit getVariable ["INC_trespassMarkerLoopRunning",false]}) exitWith {};
 
 _undercoverUnit setVariable ["INC_trespassMarkerLoopRunning",true,true];
 
@@ -45,7 +45,7 @@ _undercoverUnit setVariable ["INC_trespassMarkerLoopRunning",true,true];
 
         } count _trespassMarkers;
 
-        (!(_undercoverUnit getVariable ["isUndercover",false]) || !(alive _undercoverUnit))
+        (!(_undercoverUnit getVariable ["isUndercover",false]) || {!(alive _undercoverUnit)})
 
     };
 

--- a/INCON/INC_undercover/func/fn_undercoverTrespassRadiusLoop.sqf
+++ b/INCON/INC_undercover/func/fn_undercoverTrespassRadiusLoop.sqf
@@ -1,7 +1,8 @@
+private ["_nearReg","_nearAsym","_nearHVT","_nearSuperHVT"];
 
 params [["_undercoverUnit",player],["_regEnySide",east],["_asymEnySide",independent],["_radius1",15],["_radius2",25],["_radius3",60],["_radius4",150]];
 
-if ((!local _undercoverUnit) || (_undercoverUnit getVariable ["INC_trespassRadiusLoopRunning",false])) exitWith {};
+if ((!local _undercoverUnit) || {_undercoverUnit getVariable ["INC_trespassRadiusLoopRunning",false]}) exitWith {};
 
 _undercoverUnit setVariable ["INC_trespassRadiusLoopRunning",true,true];
 
@@ -10,11 +11,11 @@ _undercoverUnit setVariable ["INC_trespassRadiusLoopRunning",true,true];
 
 	waitUntil {
 
-		_nearReg = count ((_undercoverUnit nearEntities _radius1) select {((side _x == _regEnySide) && ((_x knowsAbout _undercoverUnit) > 1))});
+		_nearReg = count ((_undercoverUnit nearEntities _radius1) select {((side _x == _regEnySide) && {(_x knowsAbout _undercoverUnit) > 1})});
 
 		sleep 0.5;
 
-		_nearAsym = count ((_undercoverUnit nearEntities _radius2) select {((side _x == _asymEnySide) && ((_x knowsAbout _undercoverUnit) > 1))});
+		_nearAsym = count ((_undercoverUnit nearEntities _radius2) select {((side _x == _asymEnySide) && {(_x knowsAbout _undercoverUnit) > 1})});
 
 		sleep 0.5;
 
@@ -34,7 +35,7 @@ _undercoverUnit setVariable ["INC_trespassRadiusLoopRunning",true,true];
 
 		sleep 0.5;
 
-		(!(_undercoverUnit getVariable ["isUndercover",false]) || !(alive _undercoverUnit))
+		(!(_undercoverUnit getVariable ["isUndercover",false]) || {!(alive _undercoverUnit)})
 
 	};
 

--- a/INCON/INC_undercover/undercoverHandler.sqf
+++ b/INCON/INC_undercover/undercoverHandler.sqf
@@ -37,7 +37,7 @@ _undercoverUnit setVariable ["isUndercover", true, true]; //Allow scripts to pic
 
 
 if (_debug) then {
-	_undercoverUnit spawn {
+	[_undercoverUnit] spawn {
 		params ["_undercoverUnit"];
 		waitUntil {
 			sleep 5;

--- a/INCON/INC_undercover/undercoverHandler.sqf
+++ b/INCON/INC_undercover/undercoverHandler.sqf
@@ -13,13 +13,13 @@ waitUntil {!(isNull player)};
 #include "UCR_setup.sqf"
 
 //Can only be run once per unit locally on the client who is the undercover unit.
-if ((_undercoverUnit getVariable ["INC_undercoverHandlerRunning",false]) || (isDedicated) || (_undercoverUnit != player)) exitWith {};
+if ((_undercoverUnit getVariable ["INC_undercoverHandlerRunning",false]) || {isDedicated} || {_undercoverUnit != player}) exitWith {};
 
 _undercoverUnit setVariable ["INC_undercoverHandlerRunning", true, true];
 
 _undercoverUnit addMPEventHandler ["MPRespawn",{
 	_this spawn {
-		_undercoverUnit = _this select 0;
+        params ["_undercoverUnit"];
 		_undercoverUnit setVariable ["INC_undercoverHandlerRunning", false, true];
 		_underCoverUnit setVariable ["INC_armedLoopRunning", false, true];
 		_underCoverUnit setVariable ["INC_trespassLoopRunning", false, true];
@@ -38,7 +38,7 @@ _undercoverUnit setVariable ["isUndercover", true, true]; //Allow scripts to pic
 
 if (_debug) then {
 	_undercoverUnit spawn {
-		_undercoverUnit = _this select 0;
+		params ["_undercoverUnit"];
 		waitUntil {
 			sleep 5;
 
@@ -62,7 +62,7 @@ if (_debug) then {
 missionNamespace setVariable ["INC_civilianRecruitEnabled",_civRecruitEnabled,true];
 
 _undercoverUnit setCaptive false;
-_side = side _undercoverUnit;
+private _side = side _undercoverUnit;
 //Spawn the rebel commader
 [_side] remoteExecCall ["INCON_fnc_spawnRebelCommander",2];
 
@@ -176,7 +176,7 @@ waitUntil {
 	//wait until the unit is armed or trespassing
 	waitUntil {
 		sleep 3;
-		((_undercoverUnit getVariable ["INC_armed",false]) || (_undercoverUnit getVariable ["INC_trespassing",false]));
+		((_undercoverUnit getVariable ["INC_armed",false]) || {_undercoverUnit getVariable ["INC_trespassing",false]});
 	};
 
 	//Once the player is doing naughty stuff, make them vulnerable to being compromised

--- a/INCON/INC_undercover/unitInitsUndercover.sqf
+++ b/INCON/INC_undercover/unitInitsUndercover.sqf
@@ -2,18 +2,17 @@ params ["_unit"];
 
 #include "UCR_setup.sqf"
 
-if (side _unit == _regEnySide) then {
-	[_unit,_regBarbaric,_undercoverUnitSide] call INCON_fnc_undercoverKilledHandler;
+switch (side _unit) do {
+	case _regEnySide: {
+		[_unit,_regBarbaric,_undercoverUnitSide] call INCON_fnc_undercoverKilledHandler;
+	};
+	case _asymEnySide: {
+		[_unit,_asymBarbaric,_undercoverUnitSide] call INCON_fnc_undercoverKilledHandler;
+	};
 };
-
-if (side _unit == _asymEnySide) then {
-	[_unit,_asymBarbaric,_undercoverUnitSide] call INCON_fnc_undercoverKilledHandler;
-};
-
-
 
 if (_civRecruitEnabled) then {
-	if (((side _unit) == CIVILIAN) && !(_unit getVariable ["isUndercover",false])) then {
+	if (((side _unit) == CIVILIAN) && {!(_unit getVariable ["isUndercover",false])}) then {
 		[_unit,_armedCivPercentage] remoteExecCall ["INCON_fnc_recruitCiv",0,true];
 	};
 };

--- a/initUnits.sqf
+++ b/initUnits.sqf
@@ -36,14 +36,6 @@ _unit setVariable ["initLoopRunning", true, true];
 #include "INCON\INC_undercover\unitInitsUndercover.sqf"
 
 
-if (side _unit == independent) exitWith {
-	[_unit] call INCON_fnc_spawnIntelObjects;
-};
-
-if (side _unit == east) exitWith {
-	[_unit] call INCON_fnc_spawnIntelObjects;
-};
-
-if (side _unit == WEST) exitWith {
-	[_unit] call INCON_fnc_spawnIntelObjects;
+if (side _unit in [EAST,WEST,INDEPENDANT]) then {
+    [_unit] call INCON_fnc_spawnIntelObjects;
 };


### PR DESCRIPTION
Fairly light code review of the undercover script set

Mainly covers
- Lazy Evaulation
- Cleanup of empty groups
- Keeping ALiVE code inline with ALiVE API
- Privatizing Variables (Did not cover all of them)
- Code structure

**Lazy Evalauation:**
Short and sweet definition
If (A && B) then {..}
If A is false, the condition won't bother evaluating B because both variables must evaluate to true and the   value of A has already deemed that impossible
if (A && B) then {..}
If A is true but B is false, then both variables will be evaluated

In order to utilize lazy evaluation in SQF, you must put curly braces {} around the each additional component
if (A && {B}) then {...}
If (A || {B} || {C}) then {...}

**Cleanup of Empty Groups:**
A3 does not take of this automatically. This is an imperative step to remember as there is a group limit in A3.

**Keeping code inline with ALiVE API**
Fairly simple, only changed one snippet to use ALiVE API to convert a side object to a side string. This ensures future proofed reliability.

**Privatizing Variables:**
It is never a good idea to have an un-privatized variable. The easiest way to explain it is with an example

```
_bombCount = 5;
_bombType = "HE";

_bombCount  call {
 _bombType = "AP";
_this + 1
};

hint format ["%1 :: %2", _bombCount, _bombType];
```

You would expect the hint to display "6 :: HE". However, because the variable _bombType also exists inside the function call AND is not privatized, the variable in the original script will change aswell.

Simple Fix:

```
_bombCount  call {
 private _bombType = "AP";
 _this + 1
};
```

**Code Structure:**
Multiple If Thens can be combined into a [switch statement](https://community.bistudio.com/wiki/switch_do)
